### PR TITLE
Compatibility for PHP 5.3

### DIFF
--- a/src/public_html/app/code/local/C3/EnvironmentBanner/Helper/Data.php
+++ b/src/public_html/app/code/local/C3/EnvironmentBanner/Helper/Data.php
@@ -29,7 +29,8 @@ class C3_EnvironmentBanner_Helper_Data extends Mage_Core_Helper_Abstract
         }
 
         // Check that the given environment is recognised, else false
-        if (!isset($this->getEnvironments()[$this->getEnvironment()])) {
+        $environments = $this->getEnvironments();
+        if (!isset($environments[$this->getEnvironment()])) {
             return false;
         }
 
@@ -55,7 +56,8 @@ class C3_EnvironmentBanner_Helper_Data extends Mage_Core_Helper_Abstract
         }
 
         // Check that the given environment is recognised, else false
-        if (!isset($this->getEnvironments()[$this->getEnvironment()])) {
+        $environments = $this->getEnvironments();
+        if (!isset($environments[$this->getEnvironment()])) {
             return false;
         }
 
@@ -97,10 +99,11 @@ class C3_EnvironmentBanner_Helper_Data extends Mage_Core_Helper_Abstract
     {
         // Lazily load colours from environment data
         if ($this->_colours === null) {
-            if (!isset($this->getEnvironments()[$this->getEnvironment()])) {
+            $environments = $this->getEnvironments();
+            if (!isset($environments[$this->getEnvironment()])) {
                 return null;
             }
-            $data = $this->getEnvironments()[$this->getEnvironment()];
+            $data = $environments[$this->getEnvironment()];
             $this->_colours = Mage::getModel('c3_environmentbanner/colours')
                 ->setData($data);
         }


### PR DESCRIPTION
Function array dereferencing is not backward compatible so has been removed.  I have not changed the version nor repackaged, I figured you would want to do that in your own time.
